### PR TITLE
Build and collect static files

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
       - key: PYTHON_VERSION
         value: 3.11.0
       - key: DJANGO_SETTINGS_MODULE
-        value: fitness_journal.settings
+        value: fitness_journal.settings_production
       - key: SECRET_KEY
         generateValue: true
       - key: WEB_CONCURRENCY


### PR DESCRIPTION
Update `DJANGO_SETTINGS_MODULE` in `render.yaml` to `fitness_journal.settings_production` to resolve the `STATIC_ROOT` configuration error during deployment.

The build was failing because Django's `collectstatic` command was executed using the default `fitness_journal.settings` module, which lacks the `STATIC_ROOT` definition required for static file collection. By switching to `fitness_journal.settings_production`, which correctly defines `STATIC_ROOT`, the `ImproperlyConfigured` exception is avoided, allowing the build to complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b5dbc80-9032-402d-816a-599c8c4ac90c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b5dbc80-9032-402d-816a-599c8c4ac90c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

