### PR TITLE
Update WhiteNoise static file storage to preserve original filenames

### DIFF
--- a/fitness_journal/settings_production.py
+++ b/fitness_journal/settings_production.py
@@ -31,7 +31,8 @@ STATIC_URL = '/static/'
 MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
 
 # Configure whitenoise
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+# Keep original filenames to avoid 404s when templates reference non-hashed assets
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 # Security settings for production
 SECURE_BROWSER_XSS_FILTER = True


### PR DESCRIPTION
The images and static files should now load by not renaming them.